### PR TITLE
feat : 월지출/수입 통계 컴포넌트 추가, 레이아웃 정렬

### DIFF
--- a/src/routes/Calendar/Calendar.tsx
+++ b/src/routes/Calendar/Calendar.tsx
@@ -1,7 +1,49 @@
-import CalendarFormFullCalendar from './CalendarFormFullCalendar';
+import MonthStatistics from "@/components/main/MonthStatistics";
+import CalendarFormFullCalendar from "./CalendarFormFullCalendar";
+import { useLocation, Link } from "react-router-dom";
+import styled from "styled-components";
+import { SearchOutlined } from "@ant-design/icons";
 
 const Calendar = () => {
-    return <CalendarFormFullCalendar />;
+  const location = useLocation();
+
+  return (
+    <CalendarWrapper>
+      <FirstRow>
+        <h1>달력</h1>
+        <Link to="/search" isActive={location.pathname === "/search"}>
+          <StyledSearchOutlined />
+        </Link>
+      </FirstRow>
+      <MonthStatistics />
+      <CalendarFormFullCalendar />
+    </CalendarWrapper>
+  );
 };
 
 export default Calendar;
+
+const CalendarWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+`;
+
+const FirstRow = styled.div`
+  display: flex;
+  position: relative;
+  justify-content: space-between;
+  align-items: center;
+  font-size: 1.1rem;
+  width: 350px;
+  height: 40px;
+  padding: 0 10px;
+  
+`;
+
+const StyledSearchOutlined = styled(SearchOutlined)`
+  font-size : 1.8rem;
+`
+
+

--- a/src/routes/Calendar/CalendarFormFullCalendar.tsx
+++ b/src/routes/Calendar/CalendarFormFullCalendar.tsx
@@ -74,13 +74,13 @@ const CalendarFormFullCalendar = () => {
     let [income, expense, total] = eventInfo.event.title.split(",");
     return (
       <div style={{ textAlign: "right" }}>
-        <div style={{ fontSize: "0.8em", color: "green", visibility: income !== "none" ? "visible" : "hidden" }}>
+        <div style={{ fontSize: "0.8em", fontWeight: 900, color: "#34BE3A", visibility: income !== "none" ? "visible" : "hidden" }}>
           {Number(income).toLocaleString()}
         </div>
-        <div style={{ fontSize: "0.8em", color: "red", visibility: expense !== "none" ? "visible" : "hidden" }}>
+        <div style={{ fontSize: "0.8em", fontWeight: 900, color: "#ff7473", visibility: expense !== "none" ? "visible" : "hidden" }}>
           {Number(expense).toLocaleString()}
         </div>
-        <div style={{ fontSize: "0.8em", color: "black", visibility: total !== "none" ? "visible" : "hidden" }}>
+        <div style={{ fontSize: "0.8em", fontWeight: 900, color: "#333333", visibility: total !== "none" ? "visible" : "hidden" }}>
           {Number(total).toLocaleString()}
         </div>
       </div>
@@ -142,12 +142,12 @@ function renderDayCellContent(dayRenderInfo: any) {
 export default CalendarFormFullCalendar;
 
 const CalendarContainer = styled.div`
-  margin-top: 150px;
-  width: 400px;
-  padding: 32px;
+  margin-top: 2px;
+  width: 410px;
+  padding: 2px 32px 0;
 
   .fc .fc-toolbar.fc-header-toolbar {
-    margin-bottom: 0.8em; 
+    margin-bottom: 0.5em; 
   }
   .fc-button {
     padding: 2px 4px;
@@ -157,7 +157,7 @@ const CalendarContainer = styled.div`
     outline: none;
   }
   .fc-button .fc-icon {
-    color: gray;
+    color: #d9d9d9;
   }
   .fc-button:not(:disabled) {
     color: white;


### PR DESCRIPTION
월 지출/수입 통계와 달력 상태 아직 연동되지 않았음
- 스토어 전역상태 값 이용해서 변경해야 될 것 같음.